### PR TITLE
add option to disable proposal nets

### DIFF
--- a/AVATAR_MAV_README.md
+++ b/AVATAR_MAV_README.md
@@ -11,6 +11,33 @@ Writing commands below
 # [x] Gives eyeballs pose to expression param
 # [ ] Deformation field to proposal network?
 
+#### Config for no proposal sampler:
+ns-train avatarmav \
+    --output-dir disable-proposal-nets-test \
+    --pipeline.model.disable-proposal-nets True \
+    --pipeline.model.num-nerf-samples-per-ray 64 \
+    --viewer.websocket-port 6009 \
+    --viewer.quit-on-train-completion True \
+    --pipeline.datamanager.eval-num-images-to-sample-from 32 \
+    --experiment-name 074-UNION \
+    --pipeline.datamanager.pixel-sampler.num-cameras-per-batch 32 \
+    --pipeline.model.num-cameras-per-batch 32 \
+    --pipeline.model.use-l1-loss True \
+    --pipeline.model.headmodule-feature-res 128 \
+    --pipeline.model.headmodule-exp-dim 64 \
+    --pipeline.model.headmodule-deform-bs-res 64 \
+    --optimizers.fields.optimizer.lr 5e-3 \
+    --optimizers.proposal_networks.optimizer.lr 1e-3 \
+    --pipeline.model.background-color white \
+    nerfstudio-data \
+    --data nersemble_masked/074/UNION_074_EMO1234EXP234589_v16_DS2-0.5x_lmkSTAR_teethV3_SMOOTH_offsetS_whiteBg_maskBelowLine/transforms_train.json \
+    --apply-neck-rot-to-flame-pose True \
+    --apply-flame-poses-to-cams True \
+    --neck-pose-to-expr True \
+    --eyes-pose-to-expr True \
+    --scene-scale 0.2
+
+
 #### This is the general command used for final training runs:
 #!/usr/bin/env bash
 echo "Start 074..."

--- a/AVATAR_MAV_README.md
+++ b/AVATAR_MAV_README.md
@@ -14,6 +14,7 @@ Writing commands below
 #### Config for no proposal sampler:
 ns-train avatarmav \
     --output-dir disablePropNets_aabbCollider_128nerfSamples_fixSceneScale \
+    --pipeline.model.use-aabb-box-collider True \
     --pipeline.model.disable-proposal-nets True \
     --pipeline.model.num-nerf-samples-per-ray 128 \
     --viewer.websocket-port 6009 \

--- a/AVATAR_MAV_README.md
+++ b/AVATAR_MAV_README.md
@@ -13,13 +13,13 @@ Writing commands below
 
 #### Config for no proposal sampler:
 ns-train avatarmav \
-    --output-dir disable-proposal-nets-test \
+    --output-dir disablePropNets_aabbCollider_128nerfSamples_fixSceneScale \
     --pipeline.model.disable-proposal-nets True \
-    --pipeline.model.num-nerf-samples-per-ray 64 \
+    --pipeline.model.num-nerf-samples-per-ray 128 \
     --viewer.websocket-port 6009 \
     --viewer.quit-on-train-completion True \
     --pipeline.datamanager.eval-num-images-to-sample-from 32 \
-    --experiment-name 074-UNION \
+    --experiment-name $EXP_NAME \
     --pipeline.datamanager.pixel-sampler.num-cameras-per-batch 32 \
     --pipeline.model.num-cameras-per-batch 32 \
     --pipeline.model.use-l1-loss True \
@@ -30,12 +30,13 @@ ns-train avatarmav \
     --optimizers.proposal_networks.optimizer.lr 1e-3 \
     --pipeline.model.background-color white \
     nerfstudio-data \
-    --data nersemble_masked/074/UNION_074_EMO1234EXP234589_v16_DS2-0.5x_lmkSTAR_teethV3_SMOOTH_offsetS_whiteBg_maskBelowLine/transforms_train.json \
+    --data $JSON_PATH \
     --apply-neck-rot-to-flame-pose True \
     --apply-flame-poses-to-cams True \
     --neck-pose-to-expr True \
     --eyes-pose-to-expr True \
-    --scene-scale 0.2
+    --scene-scale 0.3 \
+    --disable-scaling True
 
 
 #### This is the general command used for final training runs:

--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -116,7 +116,6 @@ method_configs["avatarmav"] = TrainerConfig(
         ),
         model=AvatarMAVModelConfig(
             eval_num_rays_per_chunk=1 << 15,
-            disable_scene_contraction=True,
         ),
     ),
     optimizers={
@@ -723,3 +722,4 @@ AnnotatedBaseConfigUnion = tyro.conf.SuppressFixed[  # Don't show unparseable (f
 """Union[] type over config types, annotated with default instances for use with
 tyro.cli(). Allows the user to pick between one of several base configurations, and
 then override values in it."""
+

--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -158,6 +158,10 @@ class Nerfstudio(DataParser):
             fname = self._get_fname(filepath, data_dir)
             fnames.append(fname)
         inds = np.argsort(fnames)
+        if (selcams := os.environ.get("SELECTED_CAMS")) is not None:
+            selcams = set([int(i) for i in selcams.split()])
+            print(f"Selecting cams: {selcams}")
+            inds = [ind for ind in inds if meta["frames"][ind]["camera_index"] in selcams]
         frames = [meta["frames"][ind] for ind in inds]
 
         for frame in frames:

--- a/nerfstudio/fields/avatar_mav_field.py
+++ b/nerfstudio/fields/avatar_mav_field.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Field for compound nerf model, adds scene contraction and image embeddings to instant ngp
+Field for AvatarMAV, originally based off Nerfacto.
 """
 
 

--- a/nerfstudio/fields/avatar_mav_field.py
+++ b/nerfstudio/fields/avatar_mav_field.py
@@ -18,31 +18,19 @@ Field for AvatarMAV, originally based off Nerfacto.
 
 
 import os
-from typing import Dict, Literal, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 import torch
 from einops import rearrange
-from torch import Tensor
-from torch import functional as F
-from torch import nn
+from torch import Tensor, nn
 
 from nerfstudio.cameras.rays import RaySamples
 from nerfstudio.data.scene_box import SceneBox
 from nerfstudio.field_components.activations import trunc_exp
 from nerfstudio.field_components.avatarmav import MLP as AvatarMavMLP
 from nerfstudio.field_components.avatarmav import get_embedder
-from nerfstudio.field_components.embedding import Embedding
-from nerfstudio.field_components.encodings import HashEncoding, NeRFEncoding, SHEncoding
-from nerfstudio.field_components.field_heads import (
-    FieldHeadNames,
-    PredNormalsFieldHead,
-    SemanticFieldHead,
-    TransientDensityFieldHead,
-    TransientRGBFieldHead,
-    UncertaintyFieldHead,
-)
-from nerfstudio.field_components.mlp import MLP
+from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.field_components.spatial_distortions import SpatialDistortion
 from nerfstudio.fields.base_field import Field, get_normalized_directions
 

--- a/nerfstudio/models/avatarmav.py
+++ b/nerfstudio/models/avatarmav.py
@@ -42,7 +42,7 @@ from nerfstudio.model_components.losses import (
 )
 from nerfstudio.model_components.ray_samplers import ProposalNetworkSampler, UniformSampler
 from nerfstudio.model_components.renderers import AccumulationRenderer, DepthRenderer, NormalsRenderer, RGBRenderer
-from nerfstudio.model_components.scene_colliders import AABBBoxCollider
+from nerfstudio.model_components.scene_colliders import AABBBoxCollider, NearFarCollider
 from nerfstudio.model_components.shaders import NormalsShader
 from nerfstudio.models.base_model import Model, ModelConfig
 from nerfstudio.utils import colormaps
@@ -124,6 +124,8 @@ class AvatarMAVModelConfig(ModelConfig):
     """Use L1 loss instead of MSE loss for the RGB loss."""
     disable_proposal_nets: bool = False
     """Disable the proposal networks."""
+    use_aabb_box_collider: bool = False
+    """Use AABB box collider instead of near-far collider."""
 
 
 class AvatarMAVModel(Model):
@@ -212,8 +214,10 @@ class AvatarMAVModel(Model):
             )
 
         # Collider
-        # self.collider = NearFarCollider(near_plane=self.config.near_plane, far_plane=self.config.far_plane)
-        self.collider = AABBBoxCollider(self.scene_box)
+        if self.config.use_aabb_box_collider:
+            self.collider = AABBBoxCollider(self.scene_box)
+        else:
+            self.collider = NearFarCollider(near_plane=self.config.near_plane, far_plane=self.config.far_plane)
 
         # renderers
         self.renderer_rgb = RGBRenderer(background_color=self.config.background_color)


### PR DESCRIPTION
If `--pipeline.model.disable-proposal-nets` is `True`, use just a uniform sampler instead of nerfacto proposal networks.

Also removes scene contraction args, which was already not usable.